### PR TITLE
Adding Gamedig query possibility

### DIFF
--- a/bin/GamedigQuery.py
+++ b/bin/GamedigQuery.py
@@ -26,7 +26,7 @@ class GamedigQuery(object):
                 result['Hostname'] = json_reader['name']
                 result['Map'] = json_reader['map']
                 result['Players'] = len(json_reader['players'])
-                result['MaxPlayers'] = json_reader['maxplayers']
+                result['MaxPlayers'] = int(json_reader['maxplayers'])
                 result['Bots'] = len(json_reader['bots'])
                 result['Password'] = json_reader['password']
 
@@ -41,6 +41,7 @@ class GamedigQuery(object):
                 return False
         except:
             return False
+
 
 if __name__ == '__main__':
     gamedigQuery = GamedigQuery("wolfensteinet", "127.0.0.1", 27960)

--- a/bin/GamedigQuery.py
+++ b/bin/GamedigQuery.py
@@ -1,0 +1,47 @@
+# original author: BrandonFL
+# require gamedig: npm install -g gamedig
+
+import subprocess
+import json
+
+class GamedigQuery(object):
+    def __init__(self, game, addr, port=27015):
+        self.game, self.ip, self.port = game, addr, port
+
+    def getInfo(self):
+        try:
+            process = subprocess.Popen(
+                ['gamedig', '--type', str(self.game), '--host', str(self.ip), '--port', str(self.port)],
+                stdout=subprocess.PIPE)
+            output = process.stdout.read()
+
+            json_reader = json.loads(str(output).replace("b'", "").replace("\\n'", ""))
+
+            if 'error' in json_reader:
+                return False
+            elif 'name' in json_reader:
+                result = {}
+                result['_engine_'] = 'Gamedig'
+
+                result['Hostname'] = json_reader['name']
+                result['Map'] = json_reader['map']
+                result['Players'] = len(json_reader['players'])
+                result['MaxPlayers'] = json_reader['maxplayers']
+                result['Bots'] = len(json_reader['bots'])
+                result['Password'] = json_reader['password']
+
+                if 'secure' in json_reader['raw']:
+                    result['Secure'] = json_reader['raw']['secure']
+
+                if 'version' in json_reader['raw']:
+                    result['Version'] = json_reader['raw']['version']
+
+                return result
+            else:
+                return False
+        except:
+            return False
+
+if __name__ == '__main__':
+    gamedigQuery = GamedigQuery("wolfensteinet", "127.0.0.1", 27960)
+    print(gamedigQuery.getInfo())

--- a/bin/__init__.py
+++ b/bin/__init__.py
@@ -1,2 +1,3 @@
 from .SourceQuery import SourceQuery
 from .UT3Query import UT3Query
+from .GamedigQuery import GamedigQuery

--- a/servers.py
+++ b/servers.py
@@ -96,7 +96,7 @@ class Servers:
 
             server_cache = ServerCache(server['addr'], server['port'])
             if result:
-                server_cache.save_data(server['game'], result['GamePort'], result['Hostname'], result['Map'],result['MaxPlayers'], result['Players'], result['Bots'], result['Password'] == 0x01)
+                server_cache.save_data(server['game'], server['port'], result['Hostname'], result['Map'],result['MaxPlayers'], result['Players'], result['Bots'], result['Password'] == 0x01)
             else:
                 server_cache.set_status('Offline')
 

--- a/servers.py
+++ b/servers.py
@@ -90,6 +90,16 @@ class Servers:
                 server_cache.save_data(server['game'], result['hostport'], result['hostname'], result['map'], result['maxplayers'], result['numplayers'], 0, False)
             else:
                 server_cache.set_status('Offline')
+        elif server['type'] == 'Gamedig':
+            query = GamedigQuery(str(server['game']), str(server['addr']), int(server['port']))
+            result = query.getInfo()
+
+            server_cache = ServerCache(server['addr'], server['port'])
+            if result:
+                server_cache.save_data(server['game'], result['GamePort'], result['Hostname'], result['Map'],result['MaxPlayers'], result['Players'], result['Bots'], result['Password'] == 0x01)
+            else:
+                server_cache.set_status('Offline')
+
 
 
 # Game Server Data


### PR DESCRIPTION
# Feature

**[Add]** - Gamedig query option

# Additional documentation

To get the possibility to use Gamedig, you should get gamedig command already installed into your server. For this, you need to make this command :
`npm install -g gamedig`

Here is the list of the supported games : https://github.com/sonicsnes/node-gamedig#supported
As a game dig limitation, the game name should be equal to the **GameDig Type ID**(see upper link) if you want to use Gamedig Query 

# Exemple

Here is exemple with Wolfenstein: Enemy Territory game :
<img width="597" alt="image" src="https://user-images.githubusercontent.com/25805069/80255082-8b56a700-867c-11ea-8dc0-6f8a76fc850b.png">

# Contact 

Discord : Spooker#0001 (226715707017134080)